### PR TITLE
Update the registry index after catching up with logs with Barrier()

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -78,6 +78,7 @@ func (c *cluster) Barrier() error {
 	c.registry.Lock()
 	index := c.registry.Index()
 	c.registry.Unlock()
+
 	if index == c.raft.LastIndex() {
 		return nil
 	}
@@ -91,6 +92,9 @@ func (c *cluster) Barrier() error {
 		// TODO: add an out-of-sync error to SQLite?
 		return errors.Wrap(err, "FSM out of sync")
 	}
+	c.registry.Lock()
+	c.registry.IndexUpdate(c.raft.LastIndex())
+	c.registry.Unlock()
 
 	return nil
 }

--- a/driver.go
+++ b/driver.go
@@ -510,9 +510,6 @@ func (r *Rows) Columns() []string {
 func (r *Rows) Close() error {
 	r.rows.Close()
 
-	// FIXME: handling of batched queries seems bugg.
-	r.consumed = true
-
 	// If we consumed the whole result set, there's nothing to do as
 	// there's no pending response from the server.
 	if r.consumed {

--- a/integration_test.go
+++ b/integration_test.go
@@ -448,7 +448,7 @@ func TestIntegration_EmptyTimestamp(t *testing.T) {
 	require.NoError(t, db.Close())
 }
 
-func DISABLED_TestIntegration_QueryInterrupt(t *testing.T) {
+func TestIntegration_QueryInterrupt(t *testing.T) {
 	db, _, cleanup := newDB(t)
 	defer cleanup()
 


### PR DESCRIPTION
Also re-enable handling of large queries split into multiple responses, since it
was not the issue.