### PR TITLE
Support disabling SQLITE_CONFIG_SINGLETHREAD

### DIFF
--- a/internal/bindings/server.go
+++ b/internal/bindings/server.go
@@ -134,6 +134,11 @@ type WatchFunc func(int, int)
 
 // Init initializes dqlite global state.
 func Init() error {
+	// Don't enable single thread mode when running tests. TODO: find a
+	// better way to expose this functionality.
+	if os.Getenv("GO_DQLITE_MULTITHREAD") == "1" {
+		return nil
+	}
 	if rc := C.dqlite_initialize(); rc != 0 {
 		return fmt.Errorf("%d", rc)
 	}


### PR DESCRIPTION
This is useful when running multiple servers in the same process, e.g. unit
tests.